### PR TITLE
Add Qdrant-powered related-card recommendations (multilingual, flag-gated)

### DIFF
--- a/config.js
+++ b/config.js
@@ -41,5 +41,21 @@ module.exports = {
   AI_LOCAL_URL: process.env.AI_LOCAL_URL || 'http://llama-cpu-service:8080/v1/chat/completions',
   AI_CLOUD_URL: process.env.AI_CLOUD_URL || 'https://api.openai.com/v1/chat/completions',
   AI_GATEWAY_URL: process.env.AI_GATEWAY_URL || 'http://shared-ai-gateway:8002',
-  AI_API_KEY: process.env.AI_API_KEY || ''
+  AI_API_KEY: process.env.AI_API_KEY || '',
+
+  // Vector search (Qdrant + OVMS embeddings) — see docs/superpowers/specs/2026-05-30-qdrant-related-cards-design.md
+  VECTOR_SEARCH_ENABLED: process.env.VECTOR_SEARCH_ENABLED === 'true',
+  QDRANT_URL: process.env.QDRANT_URL || 'http://qdrant:6333',
+  QDRANT_API_KEY: process.env.QDRANT_API_KEY || '',
+  QDRANT_COLLECTION: process.env.QDRANT_COLLECTION || 'intervalai_cards',
+  OVMS_EMBED_URL: process.env.OVMS_EMBED_URL || 'http://ovms-embed:8000',
+  EMBED_MODEL_NAME: process.env.EMBED_MODEL_NAME || 'text_embed',
+  EMBED_OUTPUT_NAME: process.env.EMBED_OUTPUT_NAME || 'last_hidden_state',
+  EMBED_TOKENIZER: process.env.EMBED_TOKENIZER || 'Xenova/paraphrase-multilingual-MiniLM-L12-v2',
+  EMBED_DIM: parseInt(process.env.EMBED_DIM, 10) || 384,
+  RELATED_K_DEFAULT: parseInt(process.env.RELATED_K_DEFAULT, 10) || 5,
+  RELATED_K_MAX: parseInt(process.env.RELATED_K_MAX, 10) || 20,
+  RELATED_MIN_SCORE: process.env.RELATED_MIN_SCORE !== undefined
+    ? parseFloat(process.env.RELATED_MIN_SCORE)
+    : 0.5
 };

--- a/config.js
+++ b/config.js
@@ -59,7 +59,10 @@ module.exports = {
   EMBED_DIM: parseInt(process.env.EMBED_DIM, 10) || 1024,
   RELATED_K_DEFAULT: parseInt(process.env.RELATED_K_DEFAULT, 10) || 5,
   RELATED_K_MAX: parseInt(process.env.RELATED_K_MAX, 10) || 20,
+  // e5-large (CLS-pooled) has a high cosine floor (~0.87 even for unrelated);
+  // related concepts land ~0.93-0.96. 0.85 drops only clear outliers and lets
+  // top-k ranking surface the best matches. Tune per observed score bands.
   RELATED_MIN_SCORE: process.env.RELATED_MIN_SCORE !== undefined
     ? parseFloat(process.env.RELATED_MIN_SCORE)
-    : 0.5
+    : 0.85
 };

--- a/config.js
+++ b/config.js
@@ -45,14 +45,18 @@ module.exports = {
 
   // Vector search (Qdrant + OVMS embeddings) — see docs/superpowers/specs/2026-05-30-qdrant-related-cards-design.md
   VECTOR_SEARCH_ENABLED: process.env.VECTOR_SEARCH_ENABLED === 'true',
-  QDRANT_URL: process.env.QDRANT_URL || 'http://qdrant:6333',
+  QDRANT_URL: process.env.QDRANT_URL || 'http://qdrant.qdrant:6333',
   QDRANT_API_KEY: process.env.QDRANT_API_KEY || '',
   QDRANT_COLLECTION: process.env.QDRANT_COLLECTION || 'intervalai_cards',
-  OVMS_EMBED_URL: process.env.OVMS_EMBED_URL || 'http://ovms-embed:8000',
-  EMBED_MODEL_NAME: process.env.EMBED_MODEL_NAME || 'text_embed',
-  EMBED_OUTPUT_NAME: process.env.EMBED_OUTPUT_NAME || 'last_hidden_state',
-  EMBED_TOKENIZER: process.env.EMBED_TOKENIZER || 'Xenova/paraphrase-multilingual-MiniLM-L12-v2',
-  EMBED_DIM: parseInt(process.env.EMBED_DIM, 10) || 384,
+  // OVMS OpenAI-compatible embeddings endpoint (/v3/embeddings). e5-large is
+  // served on debian-marmoset's Intel iGPU in the `ovms` namespace.
+  OVMS_EMBED_URL: process.env.OVMS_EMBED_URL || 'http://ovms-embeddings.ovms:8000',
+  EMBED_MODEL_NAME: process.env.EMBED_MODEL_NAME || 'e5-large',
+  // e5 models expect a task prefix; "query: " is used for symmetric similarity.
+  EMBED_TEXT_PREFIX: process.env.EMBED_TEXT_PREFIX !== undefined
+    ? process.env.EMBED_TEXT_PREFIX
+    : 'query: ',
+  EMBED_DIM: parseInt(process.env.EMBED_DIM, 10) || 1024,
   RELATED_K_DEFAULT: parseInt(process.env.RELATED_K_DEFAULT, 10) || 5,
   RELATED_K_MAX: parseInt(process.env.RELATED_K_MAX, 10) || 20,
   RELATED_MIN_SCORE: process.env.RELATED_MIN_SCORE !== undefined

--- a/index.js
+++ b/index.js
@@ -312,6 +312,12 @@ if (require.main === module) {
   mlService.initialize().catch(err => {
     logger.error('Failed to initialize ML service', { error: err.message });
   });
+
+  // Ensure the Qdrant collection exists (no-op when VECTOR_SEARCH_ENABLED=false).
+  const qdrantService = require('./ml/qdrant-service');
+  qdrantService.ensureCollection().catch(err => {
+    logger.error('Failed to ensure Qdrant collection', { error: err.message });
+  });
 }
 
 module.exports = { app };

--- a/ml/card-id.js
+++ b/ml/card-id.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { v5: uuidv5 } = require('uuid');
+
+// Fixed namespace UUID for IntervalAI card point ids. Constant on purpose:
+// changing it would orphan every existing Qdrant point. Must be a valid
+// RFC-4122 UUID (uuid v14's parse() rejects non-compliant version nibbles).
+const CARD_NAMESPACE = 'f1d2c3b4-5a6e-4b7c-8d9e-0a1b2c3d4e5f';
+
+/**
+ * Map a MongoDB card ObjectId to a deterministic UUIDv5 usable as a Qdrant
+ * point id. Pure and stable: same ObjectId always yields the same UUID.
+ * @param {string|object} cardObjectId
+ * @returns {string} UUIDv5
+ */
+function cardPointId(cardObjectId) {
+  return uuidv5(String(cardObjectId), CARD_NAMESPACE);
+}
+
+module.exports = { cardPointId, CARD_NAMESPACE };

--- a/ml/embedding-client.js
+++ b/ml/embedding-client.js
@@ -54,17 +54,23 @@ class EmbeddingClient {
   async embed(text) {
     const tokenizer = await this._getTokenizer();
     const enc = await tokenizer(text, { add_special_tokens: true });
-    // enc.input_ids / enc.attention_mask are Tensors; flatten to plain arrays.
+    // enc.* are Tensors; flatten to plain arrays. The BERT IR requires three
+    // inputs: input_ids, attention_mask, AND token_type_ids (all zeros for a
+    // single sentence — the tokenizer provides them when available).
     const ids = Array.from(enc.input_ids.data, Number);
     const mask = Array.from(enc.attention_mask.data, Number);
     const seqLen = ids.length;
+    const typeIds = enc.token_type_ids
+      ? Array.from(enc.token_type_ids.data, Number)
+      : new Array(seqLen).fill(0);
 
     const resp = await axios.post(
       `${this.baseUrl}/v2/models/${this.modelName}/infer`,
       {
         inputs: [
           { name: 'input_ids', shape: [1, seqLen], datatype: 'INT64', data: ids },
-          { name: 'attention_mask', shape: [1, seqLen], datatype: 'INT64', data: mask }
+          { name: 'attention_mask', shape: [1, seqLen], datatype: 'INT64', data: mask },
+          { name: 'token_type_ids', shape: [1, seqLen], datatype: 'INT64', data: typeIds }
         ]
       },
       { timeout: 10000 }

--- a/ml/embedding-client.js
+++ b/ml/embedding-client.js
@@ -5,93 +5,54 @@ const config = require('../config');
 const logger = require('../utils/logger').child('EmbeddingClient');
 
 /**
- * Mean-pool token embeddings using the attention mask, then L2-normalize.
- * @param {number[][]} tokenEmbeddings  seqLen x dim
- * @param {number[]} attentionMask      seqLen (1 = keep, 0 = pad)
- * @returns {number[]} dim-length unit vector
+ * L2-normalize a vector. Insurance so cosine == dot product in Qdrant even if
+ * the server returns un-normalized embeddings. Idempotent on unit vectors.
+ * @param {number[]} vec
+ * @returns {number[]}
  */
-function meanPoolNormalize(tokenEmbeddings, attentionMask) {
-  const dim = tokenEmbeddings[0].length;
-  const pooled = new Array(dim).fill(0);
-  let maskSum = 0;
-  for (let t = 0; t < tokenEmbeddings.length; t++) {
-    const m = attentionMask[t] || 0;
-    if (!m) continue;
-    maskSum += m;
-    const row = tokenEmbeddings[t];
-    for (let d = 0; d < dim; d++) pooled[d] += row[d] * m;
-  }
-  const denom = maskSum > 0 ? maskSum : 1e-9;
-  for (let d = 0; d < dim; d++) pooled[d] /= denom;
+function l2normalize(vec) {
   let norm = 0;
-  for (let d = 0; d < dim; d++) norm += pooled[d] * pooled[d];
+  for (let i = 0; i < vec.length; i++) norm += vec[i] * vec[i];
   norm = Math.sqrt(norm) || 1e-9;
-  return pooled.map(v => v / norm);
+  return vec.map(v => v / norm);
 }
 
+/**
+ * Client for OVMS's OpenAI-compatible embeddings endpoint (/v3/embeddings).
+ * The model server owns tokenization, the model, and pooling — we send text
+ * and receive a vector. e5 models need a task prefix on the input text.
+ */
 class EmbeddingClient {
   constructor(opts = {}) {
     this.baseUrl = opts.baseUrl || config.OVMS_EMBED_URL;
     this.modelName = opts.modelName || config.EMBED_MODEL_NAME;
-    this.outputName = opts.outputName || config.EMBED_OUTPUT_NAME;
-    this.tokenizerName = opts.tokenizerName || config.EMBED_TOKENIZER;
-    this.tokenizer = null;
-  }
-
-  // Lazy-load the ESM-only tokenizer (no model weights, just vocab/merges).
-  async _getTokenizer() {
-    if (this.tokenizer) return this.tokenizer;
-    const { AutoTokenizer } = await import('@xenova/transformers');
-    this.tokenizer = await AutoTokenizer.from_pretrained(this.tokenizerName);
-    return this.tokenizer;
+    this.prefix = opts.prefix !== undefined ? opts.prefix : config.EMBED_TEXT_PREFIX;
   }
 
   /**
-   * Embed a single text into a 384-dim unit vector.
+   * Embed a single text into a unit vector (EMBED_DIM dimensions).
    * @param {string} text
    * @returns {Promise<number[]>}
    */
   async embed(text) {
-    const tokenizer = await this._getTokenizer();
-    const enc = await tokenizer(text, { add_special_tokens: true });
-    // enc.* are Tensors; flatten to plain arrays. The BERT IR requires three
-    // inputs: input_ids, attention_mask, AND token_type_ids (all zeros for a
-    // single sentence — the tokenizer provides them when available).
-    const ids = Array.from(enc.input_ids.data, Number);
-    const mask = Array.from(enc.attention_mask.data, Number);
-    const seqLen = ids.length;
-    const typeIds = enc.token_type_ids
-      ? Array.from(enc.token_type_ids.data, Number)
-      : new Array(seqLen).fill(0);
-
     const resp = await axios.post(
-      `${this.baseUrl}/v2/models/${this.modelName}/infer`,
-      {
-        inputs: [
-          { name: 'input_ids', shape: [1, seqLen], datatype: 'INT64', data: ids },
-          { name: 'attention_mask', shape: [1, seqLen], datatype: 'INT64', data: mask },
-          { name: 'token_type_ids', shape: [1, seqLen], datatype: 'INT64', data: typeIds }
-        ]
-      },
+      `${this.baseUrl}/v3/embeddings`,
+      { model: this.modelName, input: `${this.prefix}${text}` },
       { timeout: 10000 }
     );
 
-    const out = (resp.data.outputs || []).find(o => o.name === this.outputName)
-      || resp.data.outputs[0];
-    if (!out) throw new Error('OVMS returned no outputs');
-
-    // out.shape is [1, seqLen, dim]; out.data is a flat row-major array.
-    const dim = out.shape[out.shape.length - 1];
-    const tokenEmbeddings = [];
-    for (let t = 0; t < seqLen; t++) {
-      tokenEmbeddings.push(out.data.slice(t * dim, (t + 1) * dim));
+    const vec = resp.data && resp.data.data && resp.data.data[0]
+      ? resp.data.data[0].embedding
+      : null;
+    if (!Array.isArray(vec) || vec.length === 0) {
+      throw new Error('OVMS embeddings: no embedding in response');
     }
-    return meanPoolNormalize(tokenEmbeddings, mask);
+    return l2normalize(vec);
   }
 }
 
 // Export singleton + the pure helper + the class (for tests/custom instances).
 const embeddingClient = new EmbeddingClient();
 module.exports = embeddingClient;
-module.exports.meanPoolNormalize = meanPoolNormalize;
+module.exports.l2normalize = l2normalize;
 module.exports.EmbeddingClient = EmbeddingClient;

--- a/ml/embedding-client.js
+++ b/ml/embedding-client.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const axios = require('axios');
+const config = require('../config');
+const logger = require('../utils/logger').child('EmbeddingClient');
+
+/**
+ * Mean-pool token embeddings using the attention mask, then L2-normalize.
+ * @param {number[][]} tokenEmbeddings  seqLen x dim
+ * @param {number[]} attentionMask      seqLen (1 = keep, 0 = pad)
+ * @returns {number[]} dim-length unit vector
+ */
+function meanPoolNormalize(tokenEmbeddings, attentionMask) {
+  const dim = tokenEmbeddings[0].length;
+  const pooled = new Array(dim).fill(0);
+  let maskSum = 0;
+  for (let t = 0; t < tokenEmbeddings.length; t++) {
+    const m = attentionMask[t] || 0;
+    if (!m) continue;
+    maskSum += m;
+    const row = tokenEmbeddings[t];
+    for (let d = 0; d < dim; d++) pooled[d] += row[d] * m;
+  }
+  const denom = maskSum > 0 ? maskSum : 1e-9;
+  for (let d = 0; d < dim; d++) pooled[d] /= denom;
+  let norm = 0;
+  for (let d = 0; d < dim; d++) norm += pooled[d] * pooled[d];
+  norm = Math.sqrt(norm) || 1e-9;
+  return pooled.map(v => v / norm);
+}
+
+class EmbeddingClient {
+  constructor(opts = {}) {
+    this.baseUrl = opts.baseUrl || config.OVMS_EMBED_URL;
+    this.modelName = opts.modelName || config.EMBED_MODEL_NAME;
+    this.outputName = opts.outputName || config.EMBED_OUTPUT_NAME;
+    this.tokenizerName = opts.tokenizerName || config.EMBED_TOKENIZER;
+    this.tokenizer = null;
+  }
+
+  // Lazy-load the ESM-only tokenizer (no model weights, just vocab/merges).
+  async _getTokenizer() {
+    if (this.tokenizer) return this.tokenizer;
+    const { AutoTokenizer } = await import('@xenova/transformers');
+    this.tokenizer = await AutoTokenizer.from_pretrained(this.tokenizerName);
+    return this.tokenizer;
+  }
+
+  /**
+   * Embed a single text into a 384-dim unit vector.
+   * @param {string} text
+   * @returns {Promise<number[]>}
+   */
+  async embed(text) {
+    const tokenizer = await this._getTokenizer();
+    const enc = await tokenizer(text, { add_special_tokens: true });
+    // enc.input_ids / enc.attention_mask are Tensors; flatten to plain arrays.
+    const ids = Array.from(enc.input_ids.data, Number);
+    const mask = Array.from(enc.attention_mask.data, Number);
+    const seqLen = ids.length;
+
+    const resp = await axios.post(
+      `${this.baseUrl}/v2/models/${this.modelName}/infer`,
+      {
+        inputs: [
+          { name: 'input_ids', shape: [1, seqLen], datatype: 'INT64', data: ids },
+          { name: 'attention_mask', shape: [1, seqLen], datatype: 'INT64', data: mask }
+        ]
+      },
+      { timeout: 10000 }
+    );
+
+    const out = (resp.data.outputs || []).find(o => o.name === this.outputName)
+      || resp.data.outputs[0];
+    if (!out) throw new Error('OVMS returned no outputs');
+
+    // out.shape is [1, seqLen, dim]; out.data is a flat row-major array.
+    const dim = out.shape[out.shape.length - 1];
+    const tokenEmbeddings = [];
+    for (let t = 0; t < seqLen; t++) {
+      tokenEmbeddings.push(out.data.slice(t * dim, (t + 1) * dim));
+    }
+    return meanPoolNormalize(tokenEmbeddings, mask);
+  }
+}
+
+// Export singleton + the pure helper + the class (for tests/custom instances).
+const embeddingClient = new EmbeddingClient();
+module.exports = embeddingClient;
+module.exports.meanPoolNormalize = meanPoolNormalize;
+module.exports.EmbeddingClient = EmbeddingClient;

--- a/ml/qdrant-service.js
+++ b/ml/qdrant-service.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const { QdrantClient } = require('@qdrant/js-client-rest');
+const config = require('../config');
+const embeddingClient = require('./embedding-client');
+const { cardPointId } = require('./card-id');
+const logger = require('../utils/logger').child('QdrantService');
+
+class QdrantService {
+  constructor(opts = {}) {
+    this.enabled = opts.enabled !== undefined ? opts.enabled : config.VECTOR_SEARCH_ENABLED;
+    this.collection = opts.collection || config.QDRANT_COLLECTION;
+    this.dim = opts.dim || config.EMBED_DIM;
+    this.embeddingClient = opts.embeddingClient || embeddingClient;
+    this.client = null;
+    if (this.enabled) {
+      this.client = new QdrantClient({
+        url: config.QDRANT_URL,
+        apiKey: config.QDRANT_API_KEY || undefined
+      });
+    }
+  }
+
+  // Create the collection + userId payload index if absent. Fail-open.
+  async ensureCollection() {
+    if (!this.enabled) return;
+    try {
+      const existing = await this.client.getCollections();
+      const names = (existing.collections || []).map(c => c.name);
+      if (!names.includes(this.collection)) {
+        await this.client.createCollection(this.collection, {
+          vectors: { size: this.dim, distance: 'Cosine' }
+        });
+        await this.client.createPayloadIndex(this.collection, {
+          field_name: 'userId',
+          field_schema: 'keyword'
+        });
+        logger.info('Created Qdrant collection', { collection: this.collection });
+      }
+    } catch (err) {
+      logger.error('ensureCollection failed (continuing)', { error: err.message });
+    }
+  }
+
+  async upsertCard(card, userId) {
+    if (!this.enabled) return;
+    const text = `${card.question} ${card.answer}`;
+    const vector = await this.embeddingClient.embed(text);
+    await this.client.upsert(this.collection, {
+      points: [{
+        id: cardPointId(card._id),
+        vector,
+        payload: {
+          userId: String(userId),
+          cardId: String(card._id),
+          question: card.question,
+          answer: card.answer
+        }
+      }]
+    });
+  }
+
+  async deleteCard(cardId) {
+    if (!this.enabled) return;
+    await this.client.delete(this.collection, { points: [cardPointId(cardId)] });
+  }
+
+  // Index a whole user's deck. Embeddings are cached by text within the run
+  // (the seed deck repeats the same strings across users). Fail-open per card.
+  async indexUserDeck(user) {
+    if (!this.enabled) return;
+    const cache = new Map();
+    const points = [];
+    for (const card of user.questions) {
+      const text = `${card.question} ${card.answer}`;
+      let vector = cache.get(text);
+      if (!vector) {
+        vector = await this.embeddingClient.embed(text);
+        cache.set(text, vector);
+      }
+      points.push({
+        id: cardPointId(card._id),
+        vector,
+        payload: {
+          userId: String(user._id),
+          cardId: String(card._id),
+          question: card.question,
+          answer: card.answer
+        }
+      });
+    }
+    if (points.length) {
+      await this.client.upsert(this.collection, { points });
+    }
+    return points.length;
+  }
+
+  // Recommend by the card's stored vector, scoped to the user. `recommend`
+  // excludes the example point from results. Apply the score floor + cap.
+  async related(cardId, userId, k, minScore) {
+    if (!this.enabled) return [];
+    const res = await this.client.recommend(this.collection, {
+      positive: [cardPointId(cardId)],
+      filter: { must: [{ key: 'userId', match: { value: String(userId) } }] },
+      limit: k,
+      with_payload: true
+    });
+    return (res || [])
+      .filter(p => p.score >= minScore)
+      .slice(0, k)
+      .map(p => ({
+        cardId: p.payload.cardId,
+        question: p.payload.question,
+        answer: p.payload.answer,
+        score: p.score
+      }));
+  }
+}
+
+const qdrantService = new QdrantService();
+module.exports = qdrantService;
+module.exports.QdrantService = QdrantService;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@tensorflow/tfjs-node": "^4.22.0",
         "@tensorflow/tfjs-node-gpu": "^4.22.0",
-        "@xenova/transformers": "^2.17.2",
         "axios": "^1.13.2",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.18.3",
@@ -443,15 +442,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@huggingface/jinja": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
-      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -916,69 +906,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@qdrant/js-client-rest": {
       "version": "1.18.0",
@@ -1455,20 +1382,6 @@
       "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@xenova/transformers": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
-      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@huggingface/jinja": "^0.2.2",
-        "onnxruntime-web": "1.14.0",
-        "sharp": "^0.32.0"
-      },
-      "optionalDependencies": {
-        "onnxruntime-node": "1.14.0"
-      }
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1815,116 +1728,11 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
-      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -1955,26 +1763,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -2034,40 +1822,6 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/block-stream": {
       "version": "0.0.9",
@@ -2262,30 +2016,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -3075,21 +2805,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -3324,15 +3039,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/envinfo": {
@@ -3717,15 +3423,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -3817,15 +3514,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -3976,12 +3664,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4178,12 +3860,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/flatbuffers": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
-      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
-      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/flatted": {
       "version": "2.0.2",
@@ -4401,12 +4077,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -4683,12 +4353,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4797,12 +4461,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
     "node_modules/has-ansi": {
@@ -5037,26 +4695,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5261,12 +4899,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "1.0.1",
@@ -6411,18 +6043,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6508,12 +6128,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "11.7.5",
@@ -7076,12 +6690,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7101,36 +6709,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "license": "MIT"
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -7753,50 +7331,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/onnx-proto": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
-      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
-      "license": "MIT",
-      "dependencies": {
-        "protobufjs": "^6.8.8"
-      }
-    },
-    "node_modules/onnxruntime-common": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
-      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
-      "license": "MIT"
-    },
-    "node_modules/onnxruntime-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
-      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32",
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "onnxruntime-common": "~1.14.0"
-      }
-    },
-    "node_modules/onnxruntime-web": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
-      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
-      "license": "MIT",
-      "dependencies": {
-        "flatbuffers": "^1.12.0",
-        "guid-typescript": "^1.0.9",
-        "long": "^4.0.0",
-        "onnx-proto": "^4.0.4",
-        "onnxruntime-common": "~1.14.0",
-        "platform": "^1.3.6"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -8171,12 +7705,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT"
-    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8184,90 +7712,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/prebuild-install/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/prelude-ls": {
@@ -8328,32 +7772,6 @@
         "node": "^16 || ^18 || >=20"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8384,16 +7802,6 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8880,82 +8288,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/sharp/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/sharp/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/sharp/node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -9060,60 +8392,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
@@ -9508,17 +8786,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
-      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -9824,20 +9091,6 @@
         "inherits": "2"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/tar-pack": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
@@ -9890,18 +9143,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -9909,15 +9150,6 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
       }
     },
     "node_modules/term-size": {
@@ -9945,15 +9177,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-hex": {
@@ -10107,18 +9330,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@qdrant/js-client-rest": "^1.18.0",
         "@tensorflow/tfjs": "^4.22.0",
         "@tensorflow/tfjs-node": "^4.22.0",
         "@tensorflow/tfjs-node-gpu": "^4.22.0",
+        "@xenova/transformers": "^2.17.2",
         "axios": "^1.13.2",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.18.3",
@@ -32,6 +34,7 @@
         "passport-jwt": "^4.0.0",
         "passport-local": "^1.0.0",
         "prom-client": "^15.1.0",
+        "uuid": "^14.0.0",
         "winston": "^3.19.0"
       },
       "devDependencies": {
@@ -440,6 +443,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -905,6 +917,96 @@
         "node": ">=14"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@qdrant/js-client-rest": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.18.0.tgz",
+      "integrity": "sha512-/0dqX5uV9chC1DnYSnU4gNMrDqse/pt6hHg3Rqqpl5isH7xl1xSNvffjzBoxycDD79luWn7Ho6Rh/61sOs5DNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "undici": "^6.24.0"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "pnpm": ">=8"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -1353,6 +1455,20 @@
       "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1699,11 +1815,116 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -1734,6 +1955,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -1793,6 +2034,40 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/block-stream": {
       "version": "0.0.9",
@@ -1987,6 +2262,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2776,6 +3075,21 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -3010,6 +3324,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/envinfo": {
@@ -3394,6 +3717,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -3485,6 +3817,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -3635,6 +3976,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3831,6 +4178,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/flatted": {
       "version": "2.0.2",
@@ -4048,6 +4401,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -4324,6 +4683,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4432,6 +4797,12 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
     "node_modules/has-ansi": {
@@ -4666,6 +5037,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4870,6 +5261,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "1.0.1",
@@ -5281,6 +5678,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/which": {
@@ -6003,6 +6411,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6088,6 +6508,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "11.7.5",
@@ -6650,6 +7076,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6669,6 +7101,36 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -7291,6 +7753,50 @@
         "node": ">=4"
       }
     },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -7665,6 +8171,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -7672,6 +8184,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prelude-ls": {
@@ -7732,6 +8328,32 @@
         "node": "^16 || ^18 || >=20"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7762,6 +8384,16 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8248,6 +8880,82 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/sharp/node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -8352,6 +9060,60 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
@@ -8746,6 +9508,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -9051,6 +9824,20 @@
         "inherits": "2"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/tar-pack": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
@@ -9103,6 +9890,18 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -9110,6 +9909,15 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/term-size": {
@@ -9137,6 +9945,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-hex": {
@@ -9291,6 +10108,18 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -9346,6 +10175,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uid-number": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
@@ -9361,6 +10204,15 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -9638,13 +10490,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@tensorflow/tfjs-node": "^4.22.0",
     "@tensorflow/tfjs-node-gpu": "^4.22.0",
-    "@xenova/transformers": "^2.17.2",
     "axios": "^1.13.2",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   "author": "IntervalAI Team",
   "license": "MIT",
   "dependencies": {
+    "@qdrant/js-client-rest": "^1.18.0",
     "@tensorflow/tfjs": "^4.22.0",
     "@tensorflow/tfjs-node": "^4.22.0",
     "@tensorflow/tfjs-node-gpu": "^4.22.0",
+    "@xenova/transformers": "^2.17.2",
     "axios": "^1.13.2",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
@@ -40,6 +42,7 @@
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
     "prom-client": "^15.1.0",
+    "uuid": "^14.0.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/routes/questions.js
+++ b/routes/questions.js
@@ -9,6 +9,10 @@ const logger = require('../utils/logger').child('Questions');
 const { validate } = require('../middleware/validation');
 const { NotFoundError } = require('../utils/errors');
 const { requireAuth } = require('../middleware/cookie-auth');
+const mongoose = require('mongoose');
+const config = require('../config');
+const { BadRequestError } = require('../utils/errors');
+const qdrantService = require('../ml/qdrant-service');
 
 const router = express.Router();
 
@@ -249,6 +253,50 @@ router.patch('/settings', requireAuth, async (req, res, next) => {
       message: 'Settings updated',
       settings: user.settings
     });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/* ========== GET RELATED CARDS ========== */
+router.get('/:id/related', requireAuth, async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+    const cardId = req.params.id;
+
+    if (!mongoose.Types.ObjectId.isValid(cardId)) {
+      throw new BadRequestError('The card `id` is not valid');
+    }
+
+    const user = await User.findById(userId);
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    const card = user.questions.id(cardId);
+    if (!card) {
+      throw new NotFoundError('Card not found');
+    }
+
+    if (!qdrantService.enabled) {
+      return res.json({ related: [] });
+    }
+
+    const requestedK = parseInt(req.query.k, 10);
+    const k = Math.min(
+      Number.isInteger(requestedK) && requestedK > 0 ? requestedK : config.RELATED_K_DEFAULT,
+      config.RELATED_K_MAX
+    );
+
+    let related = [];
+    try {
+      related = await qdrantService.related(cardId, userId, k, config.RELATED_MIN_SCORE);
+    } catch (err) {
+      logger.warn('Related lookup failed (returning empty)', { cardId, error: err.message });
+      related = [];
+    }
+
+    res.json({ related });
   } catch (err) {
     next(err);
   }

--- a/routes/users.js
+++ b/routes/users.js
@@ -8,6 +8,7 @@ const createQuestions = require('../db/seed/questions');
 const logger = require('../utils/logger').child('Users');
 const { validate } = require('../middleware/validation');
 const { NotFoundError, BadRequestError, ConflictError } = require('../utils/errors');
+const qdrantService = require('../ml/qdrant-service');
 
 const router = express.Router();
 
@@ -37,6 +38,17 @@ router.post('/', validate('userRegistration'), async (req, res, next) => {
 
     const result = await User.create(newUser);
     logger.info('User created', { userId: result.id, username: result.username });
+
+    // Fire-and-forget: index the seeded deck into Qdrant. Never block or fail
+    // registration on the vector index (MongoDB is the system-of-record).
+    if (qdrantService.enabled) {
+      qdrantService.indexUserDeck(result).catch(err =>
+        logger.warn('Card indexing failed at registration', {
+          userId: result.id, error: err.message
+        })
+      );
+    }
+
     res.status(201).location(`/api/users/${result.id}`).json(result);
   } catch (err) {
     if (err.code === 11000) {

--- a/scripts/backfill-embeddings.js
+++ b/scripts/backfill-embeddings.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * One-off backfill: embed every existing user's cards into Qdrant.
+ * Usage:
+ *   VECTOR_SEARCH_ENABLED=true MONGODB_URI=... QDRANT_URL=... \
+ *   OVMS_EMBED_URL=... node scripts/backfill-embeddings.js
+ */
+
+const mongoose = require('mongoose');
+const config = require('./../config');
+const { dbConnect, dbDisconnect } = require('../db-mongoose');
+const User = require('../models/user');
+const qdrantService = require('../ml/qdrant-service');
+const logger = require('../utils/logger').child('Backfill');
+
+async function backfillAll() {
+  if (!qdrantService.enabled) {
+    logger.error('VECTOR_SEARCH_ENABLED is not true; refusing to run.');
+    return { users: 0, points: 0 };
+  }
+  await qdrantService.ensureCollection();
+
+  let users = 0;
+  let points = 0;
+  const cursor = User.find({}, 'questions').cursor();
+  for (let user = await cursor.next(); user != null; user = await cursor.next()) {
+    try {
+      const n = await qdrantService.indexUserDeck(user);
+      users += 1;
+      points += n || 0;
+      logger.info('Indexed user', { userId: user.id, cards: n });
+    } catch (err) {
+      logger.warn('Failed to index user (continuing)', { userId: user.id, error: err.message });
+    }
+  }
+  logger.info('Backfill complete', { users, points });
+  return { users, points };
+}
+
+// Run directly (not when require()'d by a test).
+if (require.main === module) {
+  (async () => {
+    await dbConnect(config.MONGODB_URI);
+    try {
+      await backfillAll();
+    } finally {
+      await dbDisconnect();
+    }
+  })().catch(err => {
+    logger.error('Backfill failed', { error: err.message });
+    process.exit(1);
+  });
+}
+
+module.exports = { backfillAll };

--- a/test/card-id.test.js
+++ b/test/card-id.test.js
@@ -1,0 +1,24 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const { cardPointId } = require('../ml/card-id');
+
+describe('cardPointId', function() {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+  it('produces a valid v5 UUID', function() {
+    expect(cardPointId('507f1f77bcf86cd799439011')).to.match(UUID_RE);
+  });
+  it('is deterministic for the same id', function() {
+    expect(cardPointId('507f1f77bcf86cd799439011'))
+      .to.equal(cardPointId('507f1f77bcf86cd799439011'));
+  });
+  it('differs for different ids', function() {
+    expect(cardPointId('507f1f77bcf86cd799439011'))
+      .to.not.equal(cardPointId('507f1f77bcf86cd799439012'));
+  });
+  it('accepts ObjectId-like objects via String()', function() {
+    const fake = { toString: () => '507f1f77bcf86cd799439011' };
+    expect(cardPointId(fake)).to.equal(cardPointId('507f1f77bcf86cd799439011'));
+  });
+});

--- a/test/config-vector.test.js
+++ b/test/config-vector.test.js
@@ -1,0 +1,17 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Vector search config', function() {
+  it('exposes vector-search defaults', function() {
+    delete require.cache[require.resolve('../config')];
+    const config = require('../config');
+    expect(config.QDRANT_COLLECTION).to.equal('intervalai_cards');
+    expect(config.EMBED_DIM).to.equal(384);
+    expect(config.EMBED_MODEL_NAME).to.equal('text_embed');
+    expect(config.RELATED_K_DEFAULT).to.equal(5);
+    expect(config.RELATED_K_MAX).to.equal(20);
+    expect(config.RELATED_MIN_SCORE).to.be.a('number');
+    expect(config.VECTOR_SEARCH_ENABLED).to.equal(false);
+  });
+});

--- a/test/config-vector.test.js
+++ b/test/config-vector.test.js
@@ -7,8 +7,8 @@ describe('Vector search config', function() {
     delete require.cache[require.resolve('../config')];
     const config = require('../config');
     expect(config.QDRANT_COLLECTION).to.equal('intervalai_cards');
-    expect(config.EMBED_DIM).to.equal(384);
-    expect(config.EMBED_MODEL_NAME).to.equal('text_embed');
+    expect(config.EMBED_DIM).to.equal(1024);
+    expect(config.EMBED_MODEL_NAME).to.equal('e5-large');
     expect(config.RELATED_K_DEFAULT).to.equal(5);
     expect(config.RELATED_K_MAX).to.equal(20);
     expect(config.RELATED_MIN_SCORE).to.be.a('number');

--- a/test/embedding-client.test.js
+++ b/test/embedding-client.test.js
@@ -1,0 +1,29 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const { meanPoolNormalize } = require('../ml/embedding-client');
+
+function l2(v) { return Math.sqrt(v.reduce((s, x) => s + x * x, 0)); }
+
+describe('meanPoolNormalize', function() {
+  it('ignores masked (0) tokens and returns a unit vector', function() {
+    // two tokens kept, one padding token masked out
+    const tokenEmbeddings = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [9, 9, 9]   // masked, must be ignored
+    ];
+    const attentionMask = [1, 1, 0];
+    const out = meanPoolNormalize(tokenEmbeddings, attentionMask);
+    expect(out).to.have.lengthOf(3);
+    expect(l2(out)).to.be.closeTo(1, 1e-6);
+    // mean of kept = [0.5,0.5,0] -> normalized -> [~0.707,~0.707,0]
+    expect(out[0]).to.be.closeTo(out[1], 1e-6);
+    expect(out[2]).to.be.closeTo(0, 1e-6);
+  });
+
+  it('handles an all-masked input without NaN', function() {
+    const out = meanPoolNormalize([[1, 2, 3]], [0]);
+    out.forEach(v => expect(Number.isNaN(v)).to.equal(false));
+  });
+});

--- a/test/embedding-client.test.js
+++ b/test/embedding-client.test.js
@@ -1,29 +1,48 @@
 'use strict';
 const chai = require('chai');
 const expect = chai.expect;
-const { meanPoolNormalize } = require('../ml/embedding-client');
+const axios = require('axios');
+const { l2normalize, EmbeddingClient } = require('../ml/embedding-client');
 
 function l2(v) { return Math.sqrt(v.reduce((s, x) => s + x * x, 0)); }
 
-describe('meanPoolNormalize', function() {
-  it('ignores masked (0) tokens and returns a unit vector', function() {
-    // two tokens kept, one padding token masked out
-    const tokenEmbeddings = [
-      [1, 0, 0],
-      [0, 1, 0],
-      [9, 9, 9]   // masked, must be ignored
-    ];
-    const attentionMask = [1, 1, 0];
-    const out = meanPoolNormalize(tokenEmbeddings, attentionMask);
-    expect(out).to.have.lengthOf(3);
+describe('l2normalize', function() {
+  it('returns a unit vector', function() {
+    const out = l2normalize([3, 4]);
     expect(l2(out)).to.be.closeTo(1, 1e-6);
-    // mean of kept = [0.5,0.5,0] -> normalized -> [~0.707,~0.707,0]
-    expect(out[0]).to.be.closeTo(out[1], 1e-6);
-    expect(out[2]).to.be.closeTo(0, 1e-6);
+    expect(out[0]).to.be.closeTo(0.6, 1e-6);
+    expect(out[1]).to.be.closeTo(0.8, 1e-6);
+  });
+  it('handles the zero vector without NaN', function() {
+    l2normalize([0, 0, 0]).forEach(v => expect(Number.isNaN(v)).to.equal(false));
+  });
+});
+
+describe('EmbeddingClient.embed', function() {
+  let origPost;
+  beforeEach(function() { origPost = axios.post; });
+  afterEach(function() { axios.post = origPost; });
+
+  it('posts prefixed text to /v3/embeddings and returns a normalized vector', async function() {
+    let captured;
+    axios.post = async (url, body) => {
+      captured = { url, body };
+      return { data: { data: [{ embedding: [3, 4] }] } };
+    };
+    const client = new EmbeddingClient({ baseUrl: 'http://ovms', modelName: 'e5-large', prefix: 'query: ' });
+    const vec = await client.embed('casa house');
+
+    expect(captured.url).to.equal('http://ovms/v3/embeddings');
+    expect(captured.body).to.deep.equal({ model: 'e5-large', input: 'query: casa house' });
+    expect(l2(vec)).to.be.closeTo(1, 1e-6); // [3,4] -> [0.6,0.8]
+    expect(vec[0]).to.be.closeTo(0.6, 1e-6);
   });
 
-  it('handles an all-masked input without NaN', function() {
-    const out = meanPoolNormalize([[1, 2, 3]], [0]);
-    out.forEach(v => expect(Number.isNaN(v)).to.equal(false));
+  it('throws when the response has no embedding', async function() {
+    axios.post = async () => ({ data: { data: [] } });
+    const client = new EmbeddingClient({ baseUrl: 'http://ovms', modelName: 'e5-large', prefix: '' });
+    let threw = false;
+    try { await client.embed('x'); } catch (e) { threw = true; }
+    expect(threw).to.equal(true);
   });
 });

--- a/test/qdrant-service.test.js
+++ b/test/qdrant-service.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const chai = require('chai');
+const expect = chai.expect;
+const { QdrantService } = require('../ml/qdrant-service');
+const { cardPointId } = require('../ml/card-id');
+
+describe('QdrantService', function() {
+  let svc, calls;
+
+  beforeEach(function() {
+    calls = { upsert: [], delete: [], recommend: [] };
+    svc = new QdrantService();
+    svc.enabled = true;
+    svc.collection = 'test_cards';
+    // Stub the Qdrant REST client
+    svc.client = {
+      upsert: async (coll, body) => { calls.upsert.push({ coll, body }); },
+      delete: async (coll, body) => { calls.delete.push({ coll, body }); },
+      recommend: async (coll, body) => {
+        calls.recommend.push({ coll, body });
+        return [
+          { id: 'x', score: 0.9, payload: { cardId: 'c1', question: 'casa', answer: 'house' } },
+          { id: 'y', score: 0.2, payload: { cardId: 'c2', question: 'sol', answer: 'sun' } }
+        ];
+      }
+    };
+    // Stub embeddings (avoid network/tokenizer)
+    svc.embeddingClient = { embed: async () => [0.1, 0.2, 0.3] };
+  });
+
+  it('upsertCard writes a point keyed by the card UUID with userId payload', async function() {
+    await svc.upsertCard({ _id: '507f1f77bcf86cd799439011', question: 'casa', answer: 'house' }, 'user1');
+    expect(calls.upsert).to.have.lengthOf(1);
+    const pt = calls.upsert[0].body.points[0];
+    expect(pt.id).to.equal(cardPointId('507f1f77bcf86cd799439011'));
+    expect(pt.payload).to.deep.include({ userId: 'user1', cardId: '507f1f77bcf86cd799439011' });
+    expect(pt.vector).to.deep.equal([0.1, 0.2, 0.3]);
+  });
+
+  it('deleteCard removes by mapped UUID', async function() {
+    await svc.deleteCard('507f1f77bcf86cd799439011');
+    expect(calls.delete[0].body.points[0]).to.equal(cardPointId('507f1f77bcf86cd799439011'));
+  });
+
+  it('related filters by userId, applies score floor, caps k', async function() {
+    const out = await svc.related('507f1f77bcf86cd799439011', 'user1', 5, 0.5);
+    const body = calls.recommend[0].body;
+    expect(body.filter.must[0]).to.deep.equal({ key: 'userId', match: { value: 'user1' } });
+    expect(body.positive[0]).to.equal(cardPointId('507f1f77bcf86cd799439011'));
+    // 0.2 result dropped by score floor
+    expect(out).to.have.lengthOf(1);
+    expect(out[0]).to.deep.equal({ cardId: 'c1', question: 'casa', answer: 'house', score: 0.9 });
+  });
+
+  it('related returns [] when disabled', async function() {
+    svc.enabled = false;
+    const out = await svc.related('507f1f77bcf86cd799439011', 'user1', 5, 0.5);
+    expect(out).to.deep.equal([]);
+  });
+});

--- a/test/questions.test.js
+++ b/test/questions.test.js
@@ -2,11 +2,10 @@
 
 const chai = require('chai');
 const chaiHttp = require('chai-http');
-const jwt = require('jsonwebtoken');
 
 const { app } = require('../index');
 const User = require('../models/user');
-const { JWT_SECRET } = require('../config');
+const { generateAccessToken } = require('../lib/auth/jwt');
 const { isDatabaseConnected, TEST_TIMEOUT } = require('./setup.test');
 
 const expect = chai.expect;
@@ -70,12 +69,8 @@ describe('Questions API', function() {
 
     testUserId = user._id;
 
-    // Create auth token
-    authToken = jwt.sign(
-      { user: { id: user._id, username: user.username } },
-      JWT_SECRET,
-      { expiresIn: '1h' }
-    );
+    // Create auth token (cookie-based; correct issuer/audience claims)
+    authToken = generateAccessToken(user);
   });
 
   after(async function() {
@@ -92,7 +87,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .get('/questions/next')
-        .set('Authorization', `Bearer ${authToken}`);
+        .set('Cookie', `accessToken=${authToken}`);
 
       expect(res).to.have.status(200);
       expect(res.body).to.have.property('question');
@@ -110,7 +105,7 @@ describe('Questions API', function() {
     it('should reject invalid token', async function() {
       const res = await chai.request(app)
         .get('/questions/next')
-        .set('Authorization', 'Bearer invalid.token.here');
+        .set('Cookie', 'accessToken=invalid.token.here');
 
       expect(res).to.have.status(401);
     });
@@ -122,7 +117,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .get('/questions/next')
-        .set('Authorization', `Bearer ${authToken}`);
+        .set('Cookie', `accessToken=${authToken}`);
 
       expect(res).to.have.status(200);
       expect(res.body).to.have.property('questionFeatures');
@@ -139,7 +134,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           answer: 'Hello',
           responseTime: 2500
@@ -160,11 +155,11 @@ describe('Questions API', function() {
       // First get the current question
       await chai.request(app)
         .get('/questions/next')
-        .set('Authorization', `Bearer ${authToken}`);
+        .set('Cookie', `accessToken=${authToken}`);
 
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           answer: 'Wrong answer',
           responseTime: 3000
@@ -182,7 +177,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           responseTime: 2000
         });
@@ -197,7 +192,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           answer: 'Hello',
           responseTime: -100
@@ -213,7 +208,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           answer: 'Hello',
           responseTime: 2000,
@@ -232,7 +227,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           answer: 'Hello',
           responseTime: 2000
@@ -251,7 +246,7 @@ describe('Questions API', function() {
       // Get the current question to find its answer
       const questionRes = await chai.request(app)
         .get('/questions/next')
-        .set('Authorization', `Bearer ${authToken}`);
+        .set('Cookie', `accessToken=${authToken}`);
 
       // Get the correct answer from the user's questions
       const user = await User.findOne({ username: testUser.username });
@@ -260,7 +255,7 @@ describe('Questions API', function() {
       // Submit the answer in UPPERCASE to test case-insensitivity
       const res = await chai.request(app)
         .post('/questions/answer')
-        .set('Authorization', `Bearer ${authToken}`)
+        .set('Cookie', `accessToken=${authToken}`)
         .send({
           answer: currentAnswer.toUpperCase(),
           responseTime: 2000
@@ -279,7 +274,7 @@ describe('Questions API', function() {
 
       const res = await chai.request(app)
         .get('/questions/stats/comparison')
-        .set('Authorization', `Bearer ${authToken}`);
+        .set('Cookie', `accessToken=${authToken}`);
 
       expect(res).to.have.status(200);
       expect(res.body).to.have.property('comparison');
@@ -301,15 +296,11 @@ describe('Questions API - Edge Cases', function() {
 
   it('should handle non-existent user gracefully', async function() {
     // Create token for non-existent user
-    const fakeToken = jwt.sign(
-      { user: { id: '000000000000000000000000', username: 'nonexistent' } },
-      JWT_SECRET,
-      { expiresIn: '1h' }
-    );
+    const fakeToken = generateAccessToken({ _id: '000000000000000000000000', username: 'nonexistent' });
 
     const res = await chai.request(app)
       .get('/questions/next')
-      .set('Authorization', `Bearer ${fakeToken}`);
+      .set('Cookie', `accessToken=${fakeToken}`);
 
     // Should return 401 since user doesn't exist (after JWT db lookup fix)
     expect(res.status).to.be.oneOf([401, 404, 500]);

--- a/test/registration-index.test.js
+++ b/test/registration-index.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+
+const { app } = require('../index');
+const User = require('../models/user');
+const qdrantService = require('../ml/qdrant-service');
+const { isDatabaseConnected, TEST_TIMEOUT } = require('./setup.test');
+
+const expect = chai.expect;
+chai.use(chaiHttp);
+
+describe('Registration indexes deck (fail-open)', function() {
+  this.timeout(TEST_TIMEOUT);
+  const savedEnabled = qdrantService.enabled;
+  const savedIndex = qdrantService.indexUserDeck;
+  const createdUsernames = [];
+  let createdUsername;
+
+  after(async function() {
+    qdrantService.enabled = savedEnabled;
+    qdrantService.indexUserDeck = savedIndex;
+    for (const u of createdUsernames) {
+      await User.deleteOne({ username: u });
+    }
+  });
+
+  it('invokes indexUserDeck for the new user when enabled', function() {
+    if (!isDatabaseConnected()) this.skip();
+    qdrantService.enabled = true;
+    let indexedDeck = null;
+    qdrantService.indexUserDeck = async (user) => {
+      indexedDeck = { username: user.username, cards: user.questions.length };
+      return user.questions.length;
+    };
+    createdUsername = `regidx_call_${Date.now()}`; createdUsernames.push(createdUsername);
+    return chai.request(app).post('/api/users').send({
+      firstName: 'Reg', lastName: 'Idx',
+      username: createdUsername, password: 'testpassword123'
+    }).then(res => {
+      expect(res).to.have.status(201);
+      expect(indexedDeck).to.not.equal(null);
+      expect(indexedDeck.username).to.equal(createdUsername);
+      expect(indexedDeck.cards).to.be.greaterThan(0); // seeded vocabulary
+    });
+  });
+
+  it('still returns 201 when indexing throws', function() {
+    if (!isDatabaseConnected()) this.skip();
+    qdrantService.enabled = true;
+    qdrantService.indexUserDeck = async () => { throw new Error('qdrant down'); };
+    createdUsername = `regidx_throw_${Date.now()}`; createdUsernames.push(createdUsername);
+    return chai.request(app).post('/api/users').send({
+      firstName: 'Reg', lastName: 'Idx',
+      username: createdUsername, password: 'testpassword123'
+    }).then(res => {
+      expect(res).to.have.status(201);
+    });
+  });
+});

--- a/test/related.test.js
+++ b/test/related.test.js
@@ -1,0 +1,99 @@
+'use strict';
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const mongoose = require('mongoose');
+
+const { app } = require('../index');
+const User = require('../models/user');
+const { generateAccessToken } = require('../lib/auth/jwt');
+const qdrantService = require('../ml/qdrant-service');
+const { isDatabaseConnected, TEST_TIMEOUT } = require('./setup.test');
+
+const expect = chai.expect;
+chai.use(chaiHttp);
+
+describe('GET /api/questions/:id/related', function() {
+  this.timeout(TEST_TIMEOUT);
+
+  let userId, token, cardId;
+  const savedEnabled = qdrantService.enabled;
+  let savedRelated;
+
+  before(async function() {
+    if (!isDatabaseConnected()) this.skip();
+    const password = await User.hashPassword('testpassword123');
+    const user = await User.create({
+      firstName: 'Rel', lastName: 'Tester',
+      username: `reltest_${Date.now()}`,
+      password, head: 0,
+      questions: [
+        { _id: new mongoose.Types.ObjectId(), question: 'casa', answer: 'house', next: 1 },
+        { _id: new mongoose.Types.ObjectId(), question: 'perro', answer: 'dog', next: 0 }
+      ]
+    });
+    userId = user.id;
+    cardId = user.questions[0]._id.toString();
+    // Mint a real access token (correct issuer/audience + user.id claim) and
+    // send it as the httpOnly cookie the middleware actually reads.
+    token = generateAccessToken(user);
+  });
+
+  after(async function() {
+    qdrantService.enabled = savedEnabled;
+    if (savedRelated) qdrantService.related = savedRelated;
+    if (userId) await User.findByIdAndDelete(userId);
+  });
+
+  it('401 without auth', function() {
+    return chai.request(app).get(`/api/questions/${cardId}/related`)
+      .then(res => expect(res).to.have.status(401));
+  });
+
+  it('returns [] when the feature is disabled', function() {
+    qdrantService.enabled = false;
+    return chai.request(app)
+      .get(`/api/questions/${cardId}/related`)
+      .set('Cookie', `accessToken=${token}`)
+      .then(res => {
+        expect(res).to.have.status(200);
+        expect(res.body.related).to.deep.equal([]);
+      });
+  });
+
+  it('404 for a card not in the user deck', function() {
+    qdrantService.enabled = true;
+    const ghost = new mongoose.Types.ObjectId().toString();
+    return chai.request(app)
+      .get(`/api/questions/${ghost}/related`)
+      .set('Cookie', `accessToken=${token}`)
+      .then(res => expect(res).to.have.status(404));
+  });
+
+  it('returns related results from the service (happy path)', function() {
+    qdrantService.enabled = true;
+    savedRelated = qdrantService.related;
+    qdrantService.related = async () => ([
+      { cardId: 'c2', question: 'perro', answer: 'dog', score: 0.88 }
+    ]);
+    return chai.request(app)
+      .get(`/api/questions/${cardId}/related?k=3`)
+      .set('Cookie', `accessToken=${token}`)
+      .then(res => {
+        expect(res).to.have.status(200);
+        expect(res.body.related).to.have.lengthOf(1);
+        expect(res.body.related[0].answer).to.equal('dog');
+      });
+  });
+
+  it('fails soft (200 []) when the service throws', function() {
+    qdrantService.enabled = true;
+    qdrantService.related = async () => { throw new Error('qdrant down'); };
+    return chai.request(app)
+      .get(`/api/questions/${cardId}/related`)
+      .set('Cookie', `accessToken=${token}`)
+      .then(res => {
+        expect(res).to.have.status(200);
+        expect(res.body.related).to.deep.equal([]);
+      });
+  });
+});

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -178,6 +178,10 @@ describe('Users API - Password Validation', function() {
       .send({ username, password });
 
     expect(res).to.have.status(200);
-    expect(res.body).to.have.property('authToken');
+    // Auth migrated to httpOnly cookies: body returns the user, and the
+    // access token arrives via Set-Cookie (not in the response body).
+    expect(res.body).to.have.nested.property('user.username', username);
+    const cookies = res.headers['set-cookie'] || [];
+    expect(cookies.some(c => c.startsWith('accessToken='))).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary
Adds per-user semantic **related-card recommendations** for the Spanish→English vocabulary deck, backed by **Qdrant as a complementary vector index** (MongoDB stays the system-of-record). Embeddings are produced by the in-cluster **OVMS `e5-large`** model (OpenAI-compatible `/v3/embeddings`, 1024-dim, CLS-pooled) on debian-marmoset's Intel iGPU.

Entirely behind `VECTOR_SEARCH_ENABLED` (default **off**) — zero behavior change until enabled.

- `ml/embedding-client.js` — text → unit vector via OVMS `/v3/embeddings` (e5 `query:` prefix, L2-normalize)
- `ml/qdrant-service.js` — collection lifecycle + `upsertCard`/`deleteCard`/`indexUserDeck`/`related` (per-user `userId` filter, score floor, top-k)
- `ml/card-id.js` — deterministic ObjectId→UUIDv5 mapping (Qdrant point ids must be u64/UUID)
- `GET /api/questions/:id/related` — fail-soft (returns `{ related: [] }` on backend error/flag-off)
- Registration hook (`routes/users.js`) — fire-and-forget index of the seeded deck (fail-open; never blocks signup)
- `scripts/backfill-embeddings.js` — one-off indexing of existing users
- Startup `ensureCollection`; new vector-search config keys
- Also migrated stale Bearer-header auth tests → httpOnly-cookie auth (they predated the cookie migration and only passed because CI skips DB tests)

## Design
Spec + plan in the parent repo: `docs/superpowers/specs/2026-05-30-qdrant-related-cards-design.md`, `docs/superpowers/plans/2026-05-30-qdrant-related-cards.md`.

## Test Plan
- [x] `npm run test:once` — 132 passing, 0 failing (unit: pooling/normalize, card-id, qdrant-service; integration: `/related` auth/404/happy/fail-soft, registration fail-open)
- [x] OVMS `/v3/embeddings` verified discriminating in-cluster (casa↔house 0.96, unrelated ~0.87)
- [ ] After merge: wire `intervalai` env (`QDRANT_URL`, `OVMS_EMBED_URL`, flag) in `helm-charts/intervalai`, enable, run backfill, smoke-test `/api/questions/:id/related`

## Notes
- Fail-open writes / fail-soft reads; feature flag default off (dark launch)
- `RELATED_MIN_SCORE=0.85` reflects e5's high cosine floor (~0.87 unrelated); top-k ranking carries the signal