### PR TITLE
build: ship backfill-embeddings.js in the server image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,8 @@ coverage/
 # ML Training data (optional - include if models are pre-trained)
 training-data/
 scripts/
+# ...but keep the backfill script in the image (run via `node scripts/backfill-embeddings.js`)
+!scripts/backfill-embeddings.js
 
 # Logs
 logs/


### PR DESCRIPTION
## Summary
`scripts/` is excluded by `.dockerignore`, so `scripts/backfill-embeddings.js` wasn't in the image — the Qdrant backfill had to be `kubectl cp`'d into the pod manually at enable time. Re-include just that one script (heavy training/simulation scripts stay excluded) so `node scripts/backfill-embeddings.js` works in-pod.

## Test Plan
- [x] `.dockerignore` keeps `scripts/` ignored, re-includes only `backfill-embeddings.js`
- [ ] Next image build → confirm `/app/scripts/backfill-embeddings.js` present in the container